### PR TITLE
Simplify config strings

### DIFF
--- a/src/main/resources/assets/bettergrass/lang/en_us.json
+++ b/src/main/resources/assets/bettergrass/lang/en_us.json
@@ -3,7 +3,7 @@
   "bettergrass.midnightconfig.category.config": "General",
   "bettergrass.midnightconfig.warn":"\u00A7cWorld reload or F3+A is required to apply changes.",
   "bettergrass.midnightconfig.betterGrassMode":"Better Grass Mode",
-  "bettergrass.midnightconfig.betterGrassMode.tooltip":"\u00A74Off \u00A7r- Grass Blocks will look normal\n\u00A73Fast \u00A7r- Top Grass texture will be applied on all the sides of Grass Blocks (fast)\n\u00A7dFancy \u00A7r- Top Grass texture will be applied dynamically on the sides of Grass Blocks (slow)",
+  "bettergrass.midnightconfig.betterGrassMode.tooltip":"\u00A74Off \u00A7r- Grass Blocks look normal\n\u00A73Fast \u00A7r- Top Grass texture will be applied to all sides of the Grass Blocks (fast)\n\u00A7dFancy \u00A7r- Top Grass texture will be applied dynamically to required sides of the Grass Blocks (slow)",
   "bettergrass.midnightconfig.enum.BetterGrassMode.OFF":"Off",
   "bettergrass.midnightconfig.enum.BetterGrassMode.FAST":"Fast",
   "bettergrass.midnightconfig.enum.BetterGrassMode.FANCY":"Fancy",

--- a/src/main/resources/assets/bettergrass/lang/en_us.json
+++ b/src/main/resources/assets/bettergrass/lang/en_us.json
@@ -1,13 +1,13 @@
 {
   "bettergrass.midnightconfig.title":"FabricBetterGrass",
-  "bettergrass.midnightconfig.category.config": "Config",
-  "bettergrass.midnightconfig.warn":"\u00A74This option can only be changed at the Main Menu screen!",
+  "bettergrass.midnightconfig.category.config": "General",
+  "bettergrass.midnightconfig.warn":"\u00A7cWorld reload or F3+A is required to apply changes.",
   "bettergrass.midnightconfig.betterGrassMode":"Better Grass Mode",
-  "bettergrass.midnightconfig.betterGrassMode.tooltip":"\u00A74Off \u00A7r- Grass Blocks will look normal\n\u00A73Fast \u00A7r- Top Grass texture will be applied on all the sides of Grass Blocks (fast)\n\u00A7dFancy \u00A7r- Top Grass texture will be applied dynamically on the sides of Grass Blocks (slow)\n\n\u00A77When ON, makes grassy terrains look smooth!",
+  "bettergrass.midnightconfig.betterGrassMode.tooltip":"\u00A74Off \u00A7r- Grass Blocks will look normal\n\u00A73Fast \u00A7r- Top Grass texture will be applied on all the sides of Grass Blocks (fast)\n\u00A7dFancy \u00A7r- Top Grass texture will be applied dynamically on the sides of Grass Blocks (slow)",
   "bettergrass.midnightconfig.enum.BetterGrassMode.OFF":"Off",
   "bettergrass.midnightconfig.enum.BetterGrassMode.FAST":"Fast",
   "bettergrass.midnightconfig.enum.BetterGrassMode.FANCY":"Fancy",
-  "bettergrass.midnightconfig.category.advanced": "For advanced users only!",
-  "bettergrass.midnightconfig.blockstates":"Grass Blocks",
-  "bettergrass.midnightconfig.blockstates.tooltip":"Grass Blocks to be better grassified."
+  "bettergrass.midnightconfig.category.advanced": "Advanced",
+  "bettergrass.midnightconfig.blockstates":"Connected blocks",
+  "bettergrass.midnightconfig.blockstates.tooltip":"Grass-like blocks that should be connected on slopes."
 }


### PR DESCRIPTION
Applies several changes to the config strings to make them less confusing.

- "Config" and "For advanced users only!" switched to "General" and "Advanced" respectively
- The warning label now has a lighter red color (for visibility) and is more actionable
- "When ON, makes grassy terrains look smooth!" removed from tooltip because there is no "ON" option and the other options already describe themselves
- Blockstates label and tooltip changed to better reflect what it does
- Grammar, wording